### PR TITLE
Refactor all transforms and casts

### DIFF
--- a/lib/data/gateways/sembast_database.dart
+++ b/lib/data/gateways/sembast_database.dart
@@ -117,29 +117,14 @@ class SembastDatabaseImpl implements SembastDatabase {
   @override
   Future<Stream<List<Map<String, dynamic>>>> listenAll({required String store}) async {
     final storeMap = stringMapStoreFactory.store(store);
-    return storeMap.query().onSnapshots(_db).transform(snapshotsTransformer);
+    // Maps a list of `sembast` snapshot records into a list of objects
+    return storeMap.query().onSnapshots(_db).map((snapshots) => snapshots.map((record) => record.value).toList());
   }
 
   @override
   Future<Stream<Map<String, dynamic>?>> listenTo({required String id, required String store}) async {
     final storeMap = stringMapStoreFactory.store(store);
-    return storeMap.record(id).onSnapshot(_db).transform(snapshotTransformer);
+    // Maps a single `sembast` snapshot record into an object
+    return storeMap.record(id).onSnapshot(_db).map((snapshot) => snapshot?.value);
   }
-
-  /// Transforms a list of `sembast` snapshot records into a list of objects
-  final snapshotsTransformer =
-      StreamTransformer<List<RecordSnapshot<String, Map<String, Object?>>>, List<Map<String, Object?>>>.fromHandlers(
-    handleData: (snapshots, sink) {
-      final transformedRecords = snapshots.map((record) => record.value).toList();
-      sink.add(transformedRecords);
-    },
-  );
-
-  /// Transforms a single `sembast` snapshot record into an object
-  final snapshotTransformer =
-      StreamTransformer<RecordSnapshot<String, Map<String, Object?>>?, Map<String, Object?>?>.fromHandlers(
-    handleData: (snapshot, sink) {
-      sink.add(snapshot?.value);
-    },
-  );
 }

--- a/lib/data/serializers/collection_serializer.dart
+++ b/lib/data/serializers/collection_serializer.dart
@@ -23,8 +23,7 @@ class CollectionSerializer implements Serializer<Collection, Map<String, dynamic
     final category = json[CollectionKeys.category] as String;
 
     final rawTags = json[CollectionKeys.tags] as List;
-    // Casting just to make sure, because sembast returns an ImmutableList<dynamic>
-    final tags = rawTags.cast<String>();
+    final tags = List<String>.from(rawTags);
 
     final uniqueMemosAmount = json[CollectionKeys.uniqueMemosAmount] as int;
     final uniqueMemoExecutionsAmount = json[CollectionKeys.uniqueMemoExecutionsAmount] as int?;

--- a/lib/data/serializers/memo_collection_metadata_serializer.dart
+++ b/lib/data/serializers/memo_collection_metadata_serializer.dart
@@ -12,7 +12,6 @@ class MemoCollectionMetadataSerializer implements Serializer<MemoCollectionMetad
   MemoCollectionMetadata from(Map<String, dynamic> json) {
     final uniqueId = json[MemoCollectionMetadataKeys.uniqueId] as String;
 
-    // Casting just to make sure, because sembast returns an ImmutableList<dynamic>
     final rawQuestion = List<Map<String, dynamic>>.from(json[MemoCollectionMetadataKeys.rawQuestion] as List);
     final rawAnswer = List<Map<String, dynamic>>.from(json[MemoCollectionMetadataKeys.rawAnswer] as List);
 

--- a/lib/data/serializers/memo_execution_serializer.dart
+++ b/lib/data/serializers/memo_execution_serializer.dart
@@ -24,9 +24,8 @@ class MemoExecutionSerializer implements Serializer<MemoExecution, Map<String, d
     final rawFinished = json[MemoExecutionKeys.finished] as int;
     final finished = DateTime.fromMillisecondsSinceEpoch(rawFinished, isUtc: true);
 
-    // Casting just to make sure, because sembast returns an ImmutableList<dynamic>
-    final rawQuestion = (json[MemoExecutionKeys.rawQuestion] as List).cast<Map<String, dynamic>>();
-    final rawAnswer = (json[MemoExecutionKeys.rawAnswer] as List).cast<Map<String, dynamic>>();
+    final rawQuestion = List<Map<String, dynamic>>.from(json[MemoExecutionKeys.rawQuestion] as List);
+    final rawAnswer = List<Map<String, dynamic>>.from(json[MemoExecutionKeys.rawAnswer] as List);
 
     final rawDifficulty = json[MemoExecutionKeys.markedDifficulty] as String;
     final markedDifficulty = memoDifficultyFromRaw(rawDifficulty);

--- a/lib/data/serializers/memo_serializer.dart
+++ b/lib/data/serializers/memo_serializer.dart
@@ -21,9 +21,8 @@ class MemoSerializer implements Serializer<Memo, Map<String, dynamic>> {
     final collectionId = json[MemoKeys.collectionId] as String;
     final uniqueId = json[MemoKeys.uniqueId] as String;
 
-    // Casting just to make sure, because sembast returns an ImmutableList<dynamic>
-    final rawQuestion = (json[MemoKeys.rawQuestion] as List).cast<Map<String, dynamic>>();
-    final rawAnswer = (json[MemoKeys.rawAnswer] as List).cast<Map<String, dynamic>>();
+    final rawQuestion = List<Map<String, dynamic>>.from(json[MemoExecutionKeys.rawQuestion] as List);
+    final rawAnswer = List<Map<String, dynamic>>.from(json[MemoExecutionKeys.rawAnswer] as List);
 
     final rawExecutionsAmounts = json[MemoKeys.executionsAmounts] as Map<String, dynamic>?;
     final executionsAmounts =


### PR DESCRIPTION
- Transforms gives us no clear benefit (in our use-case). Using `Stream.map` is simpler;
- Calling a `.cast` in a collection creates a `CastMap`, which only throws errors when accessing the properties, and we don't want that, we want the serializers to throw errors as soon as possible.