### PR TITLE
Improves iOS release workflow performance

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.olmps.memoClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.olmps.memoClient";
+				PROVISIONING_PROFILE_SPECIFIER = "Memo Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -474,7 +474,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -515,7 +516,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.olmps.memoClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.olmps.memoClient";
+				PROVISIONING_PROFILE_SPECIFIER = "Memo Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -530,7 +531,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 583UZTNE98;
@@ -542,7 +542,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.olmps.memoClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.olmps.memoClient";
+				PROVISIONING_PROFILE_SPECIFIER = "Memo Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/ios/exportOptions.plist
+++ b/ios/exportOptions.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>compileBitcode</key>
+    <true/>
+    <key>method</key>
+    <string>app-store</string>
+    <key>provisioningProfiles</key>
+    <dict>
+      <key>com.olmps.memoClient</key>
+      <string>match AppStore com.olmps.memoClient</string>
+    </dict>
+    <key>signingCertificate</key>
+    <string>iOS Distribution</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>thinning</key>
+    <string>&lt;none&gt;</string>
+  </dict>
+</plist>

--- a/ios/exportOptions.plist
+++ b/ios/exportOptions.plist
@@ -9,7 +9,7 @@
     <key>provisioningProfiles</key>
     <dict>
       <key>com.olmps.memoClient</key>
-      <string>match AppStore com.olmps.memoClient</string>
+      <string>Memo Distribution</string>
     </dict>
     <key>signingCertificate</key>
     <string>iOS Distribution</string>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -78,9 +78,6 @@ platform :ios do
     # Run Analyzer
     sh("flutter", "analyze", ".")
 
-    # Run flutter build with release mode
-    sh("flutter", "build", "ios", "--release", "--dart-define=ENV=PROD")
-
     # Increment the build number (use the latest build number for this version + 1)
     increment_build_number(
       build_number: latest_testflight_build_number(
@@ -91,16 +88,8 @@ platform :ios do
       xcodeproj: "Runner.xcodeproj",
     )
 
-    # Build the app
-    build_ios_app(
-      scheme: "Runner",
-      export_options: {
-        method: "app-store",
-        provisioningProfiles: { 
-          "com.olmps.memoClient" => "match AppStore com.olmps.memoClient"
-        }
-      }
-    )
+    # Run flutter build with release mode
+    sh("flutter", "build", "ipa", "--release", "--dart-define=ENV=PROD", "--export-options-plist=ios/exportOptions.plist")
 
     # Upload dSYM files to Firebae Crashlytics
     # TODO

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -101,10 +101,8 @@ platform :ios do
       api_key: api_key,
       skip_waiting_for_build_processing: true,
       distribute_external: true,
-      changelog: changelog
+      changelog: changelog,
+      ipa: '../build/ios/ipa/Memo.ipa'
     )
-
-    # Clean local dSYM and IPA files
-    clean_build_artifacts
   end
 end


### PR DESCRIPTION
Relates to #94 improving the iOS release workflow performance. Previously we were building the iOS app twice. Now we take advantage from `flutter build ipa` to build the app once