### PR TITLE
Bumps both workflows Flutter version to `2.2.3` (latest stable version)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  flutter_version: "2.2.0"
+  flutter_version: "2.2.3"
   java_version: "12.x"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  flutter_version: "2.0.6"
+  flutter_version: "2.2.3"
   java_version: "12.x"
 
 jobs:


### PR DESCRIPTION
Aims to fix broken CI release workflow https://github.com/olmps/memo/actions/runs/1031681878