### PR TITLE
Updates Android & iOS release lanes to distribute beta build to external users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ a beta or production release, they must be documented here).
 
 ## [Unreleased]
 
+## Updated
+- Android & iOS Fastfiles to automatically distribute uploaded builds to external testers.
+
 ## [0.1.0] - 2021-07-16
 
 ## Added

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -30,6 +30,7 @@ platform :android do
       skip_upload_images: true,
       skip_upload_screenshots: true,
       skip_upload_apk: true,
+      skip_upload_metadata: true,
       version_name: version_info["version_name"],
       version_code: android_get_version_code(),
       aab: "../build/app/outputs/bundle/release/app-release.aab",

--- a/android/fastlane/metadata/android/pt-BR/changelogs/5.txt
+++ b/android/fastlane/metadata/android/pt-BR/changelogs/5.txt
@@ -1,0 +1,1 @@
+Primeira versão do Memo!

--- a/android/fastlane/metadata/android/pt-BR/changelogs/default.txt
+++ b/android/fastlane/metadata/android/pt-BR/changelogs/default.txt
@@ -1,0 +1,1 @@
+Correções de bugs e melhorias

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -110,8 +110,10 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true,
       distribute_external: true,
+      groups: [
+        'External Testers'
+      ],
       changelog: changelog,
       ipa: '../build/ios/ipa/Memo.ipa'
     )


### PR DESCRIPTION
Introduces a performance improvement to release workflow that may save around 5 minutes, according to the last release workflow logs:

![CleanShot 2021-07-16 at 11 10 12@2x](https://user-images.githubusercontent.com/11745745/125961719-0adeb4d1-05df-42fe-b4ca-07217243f29c.png)

It basically ignores the processing time from AppStoreConnect. It doesn't make sense to wait for it since we'll need to manually release it latter in the portal.