### PR TITLE
Bumps `flutter_quill` to fix placeholder issue

### DIFF
--- a/lib/application/widgets/theme/rich_text_field.dart
+++ b/lib/application/widgets/theme/rich_text_field.dart
@@ -391,9 +391,7 @@ class _ThemedEditor extends ConsumerWidget {
       padding: EdgeInsets.zero,
       enableInteractiveSelection: !readOnly,
       showCursor: !readOnly,
-      // TODO(ggirotto): Placeholder is crashing. This is a problem related to `FlutterQuill`.
-      // TODO(ggirotto): https://github.com/singerdmx/flutter-quill/issues/348
-      // placeholder: placeholder,
+      placeholder: placeholder,
       customStyles: quill.DefaultStyles(
         paragraph: quill.DefaultTextBlockStyle(textTheme.bodyText2!, zeroTuple, zeroTuple, null),
         placeHolder: quill.DefaultTextBlockStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -285,7 +285,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.14"
+    version: "2.0.22"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   layoutr: ^1.0.0
 
   # Keep dependency locked, as we need it to be the exact same in `memo-editor`
-  flutter_quill: 2.0.14
+  flutter_quill: 2.0.22
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The issue was fixed (I guess) in this PR https://github.com/singerdmx/flutter-quill/pull/484. Tested in the app and the crash is not happening anymore