### PR TITLE
Updates all tests to use `sinon.sandbox`

### DIFF
--- a/firebase/test/core/data/gateways/filesystem-gateway.spec.ts
+++ b/firebase/test/core/data/gateways/filesystem-gateway.spec.ts
@@ -18,15 +18,17 @@ describe("FileSystemGateway", () => {
   // TODO(matuella): How to mock while maintaining types?
   // This way, we won't have to call `fsMock.expect("unsafeMethodCall")` and could
   // possibly use `createSinonStub`
+  let sandbox: sinon.SinonSandbox;
   let fsMock: sinon.SinonMock;
 
   beforeEach(() => {
-    fsMock = sinon.mock(fs.promises);
-    sinon.stub(process, "cwd").returns(fakeCwd);
+    sandbox = sinon.createSandbox();
+    fsMock = sandbox.mock(fs.promises);
+    sandbox.stub(process, "cwd").returns(fakeCwd);
   });
 
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it("should reject when readdir throws", async () => {

--- a/firebase/test/core/data/gateways/firestore-gateways.spec.ts
+++ b/firebase/test/core/data/gateways/firestore-gateways.spec.ts
@@ -13,16 +13,18 @@ import FirebaseFirestoreError from "#faults/errors/firebase-firestore-error";
 describe("FirestoreGateway", () => {
   const fakeCollection = "collections";
 
+  let sandbox: sinon.SinonSandbox;
   let firestoreMock: sinon.SinonStubbedInstance<firebase.firestore.Firestore>;
   let firestoreGateway: FirestoreGateway;
 
   beforeEach(() => {
-    firestoreMock = createSinonStub(firebase.firestore.Firestore);
+    sandbox = sinon.createSandbox();
+    firestoreMock = sandbox.createStubInstance(firebase.firestore.Firestore);
     firestoreGateway = new FirestoreGateway(firestoreMock as firebase.firestore.Firestore);
   });
 
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   function createTransactionMock(): sinon.SinonStubbedInstance<firebase.firestore.Transaction> {

--- a/firebase/test/core/data/gateways/shell-gateway.spec.ts
+++ b/firebase/test/core/data/gateways/shell-gateway.spec.ts
@@ -8,14 +8,16 @@ describe("ShellGateway", () => {
   // TODO(matuella): How to mock while maintaining types?
   // This way, we won't have to call `fsMock.expect("unsafeMethodCall")` and could
   // possibly use `createSinonStub`
+  let sandbox: sinon.SinonSandbox;
   let childProcessMock: sinon.SinonMock;
 
   beforeEach(() => {
-    childProcessMock = sinon.mock(child_process);
+    sandbox = sinon.createSandbox();
+    childProcessMock = sandbox.mock(child_process);
   });
 
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it("should reject when exec returns an error", async () => {

--- a/firebase/test/core/data/repositories/git-repository.spec.ts
+++ b/firebase/test/core/data/repositories/git-repository.spec.ts
@@ -4,11 +4,18 @@ import { ShellGateway } from "#data/gateways/shell-gateway";
 import { GitRepository } from "#data/repositories/git-repository";
 
 describe("GitRepository", () => {
-  const shellMock = sinon.createStubInstance(ShellGateway);
-  const gitRepo = new GitRepository(shellMock);
+  let sandbox: sinon.SinonSandbox;
+  let shellMock: sinon.SinonStubbedInstance<ShellGateway>;
+  let gitRepo: GitRepository;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    shellMock = sandbox.createStubInstance(ShellGateway);
+    gitRepo = new GitRepository(shellMock);
+  });
 
   afterEach(() => {
-    shellMock.run.reset();
+    sandbox.reset();
   });
 
   it("should use rev-list to fetch the last merge commit hash", async () => {

--- a/firebase/test/core/data/repositories/local-collections-repository.spec.ts
+++ b/firebase/test/core/data/repositories/local-collections-repository.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as sinon from "sinon";
 import { FileSystemGateway } from "#data/gateways/filesystem-gateway";
 import { SchemaValidator } from "#data/schemas/schema-validator";
 import { LocalCollectionsRepository } from "#data/repositories/local-collections-repository";
@@ -8,9 +9,26 @@ import { LocalPublicCollection } from "#domain/models/collection";
 import createSinonStub from "#test/sinon-stub";
 
 describe("LocalCollectionsRepository", () => {
-  const fsGatewayStub = createSinonStub(FileSystemGateway);
-  const schemaValidatorStub = createSinonStub(SchemaValidator);
-  const localCollectionsRepo = new LocalCollectionsRepository(fsGatewayStub, schemaValidatorStub, "any");
+  let sandbox: sinon.SinonSandbox;
+  let fsGatewayStub: sinon.SinonStubbedInstance<FileSystemGateway>;
+  let schemaValidatorStub: sinon.SinonStubbedInstance<SchemaValidator>;
+  let localCollectionsRepo: LocalCollectionsRepository;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    const fsStub = createSinonStub(FileSystemGateway);
+    fsGatewayStub = fsStub;
+
+    const schemaStub = createSinonStub(SchemaValidator);
+    schemaValidatorStub = schemaStub;
+
+    localCollectionsRepo = new LocalCollectionsRepository(fsStub, schemaStub, "any");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   describe("getAllCollectionsByIds", () => {
     it("should return local stored collections", async () => {

--- a/firebase/test/core/data/schemas/memo.spec.ts
+++ b/firebase/test/core/data/schemas/memo.spec.ts
@@ -16,7 +16,7 @@ describe("Memo Schema Validation", () => {
   it("should throw when question id is not present", () => {
     const rawMemo = _newRawMemo();
 
-    delete rawMemo.uniqueId;
+    delete rawMemo.id;
 
     throws(() => validator.validateObject("memo", rawMemo), SerializationError);
   });

--- a/firebase/test/sinon-stub.ts
+++ b/firebase/test/sinon-stub.ts
@@ -3,6 +3,13 @@ import * as sinon from "sinon";
 type StubbedClass<T> = sinon.SinonStubbedInstance<T> & T;
 
 /** Creates a type-casted sinon Stub. */
-export default function createSinonStub<T>(constructor: sinon.StubbableType<T>): StubbedClass<T> {
+export default function createSinonStub<T>(
+  constructor: sinon.StubbableType<T>,
+  sandbox?: sinon.SinonSandbox
+): StubbedClass<T> {
+  if (sandbox !== undefined) {
+    return sandbox.createStubInstance(constructor) as StubbedClass<T>;
+  }
+
   return sinon.createStubInstance(constructor) as StubbedClass<T>;
 }


### PR DESCRIPTION
Updates unit tests to use Sandbox instead stubbing classes directly.
This avoids stubs reuse between test files.