### PR TITLE
Removes unique validation from Memo's content

### DIFF
--- a/firebase/src/core/data/schemas/entities-schemas/memo.json
+++ b/firebase/src/core/data/schemas/entities-schemas/memo.json
@@ -11,16 +11,14 @@
       "items": {
         "allOf": [{ "$ref": "memo-content#" }]
       },
-      "minItems": 1,
-      "uniqueItems": true
+      "minItems": 1
     },
     "answer": {
       "type": "array",
       "items": {
         "allOf": [{ "$ref": "memo-content#" }]
       },
-      "minItems": 1,
-      "uniqueItems": true
+      "minItems": 1
     }
   },
   "required": [

--- a/firebase/src/core/domain/models/memo.ts
+++ b/firebase/src/core/domain/models/memo.ts
@@ -29,8 +29,8 @@ export const memoQuillValidationSchema = Joi.object({
 
 export const memoValidationSchema = Joi.object({
   id: Joi.string().max(defaultMaxStringLength).required(),
-  question: Joi.array().items(memoQuillValidationSchema).unique().min(1).required(),
-  answer: Joi.array().items(memoQuillValidationSchema).unique().min(1).required(),
+  question: Joi.array().items(memoQuillValidationSchema).min(1).required(),
+  answer: Joi.array().items(memoQuillValidationSchema).min(1).required(),
 });
 
 export function validateMemo(memo: Memo): void {

--- a/firebase/test/core/data/schemas/memo.spec.ts
+++ b/firebase/test/core/data/schemas/memo.spec.ts
@@ -3,17 +3,13 @@ import { SchemaValidator } from "#data/schemas/schema-validator";
 import { doesNotThrow, throws } from "assert";
 import SerializationError from "#faults/errors/serialization-error";
 import { SchemaTester, ValidationProperties } from "#testentity-tester";
-import { newRawMemo, newRawMemoContent } from "./collections-fakes";
+import { newRawMemo } from "./collections-fakes";
 
 describe("Memo Schema Validation", () => {
   describe("Root Properties - ", () => {
     const properties: ValidationProperties = {
       required: ["id", "question", "answer"],
       array: ["question", "answer"],
-      uniqueItems: new Map<string, any[]>([
-        ["question", [newRawMemoContent(), newRawMemoContent()]],
-        ["answer", [newRawMemoContent(), newRawMemoContent()]],
-      ]),
       incorrectTypes: new Map<string, any>([
         ["id", true],
         ["question", "string"],

--- a/firebase/test/core/domain/models/memo.spec.ts
+++ b/firebase/test/core/domain/models/memo.spec.ts
@@ -10,10 +10,6 @@ describe("Memo Content Validation", () => {
     const properties: ValidationProperties = {
       required: ["id", "question", "answer"],
       array: ["question", "answer"],
-      uniqueItems: new Map<string, any[]>([
-        ["question", [newRawMemoContent(), newRawMemoContent()]],
-        ["answer", [newRawMemoContent(), newRawMemoContent()]],
-      ]),
       incorrectTypes: new Map<string, any>([
         ["id", true],
         ["question", "string"],


### PR DESCRIPTION
The motivation for this change is that there is the possibility of Memos having duplicate content. A good example is `guia_scrum.json` collection, which has the following Memo:

<details>
<summary>Memo</summary>

```json
{
      "id": "ff19caf7-a8fa-4bcc-824f-014cb187ef99",
      "question": [
        {
          "insert": "Os cinco valores do Scrum são: __________.\n"
        }
      ],
      "answer": [
        {
          "insert": "Os cinco valores do Scrum são: "
        },
        {
          "insert": "COMPROMISSO",
          "attributes": {
            "bold": true,
            "underline": true
          }
        },
        {
          "insert": ", "
        },
        {
          "insert": "FOCO",
          "attributes": {
            "bold": true,
            "underline": true
          }
        },
        {
          "insert": ", "
        },
        {
          "insert": "ABERTURA",
          "attributes": {
            "bold": true,
            "underline": true
          }
        },
        {
          "insert": ", "
        },
        {
          "insert": "RESPEITO",
          "attributes": {
            "bold": true,
            "underline": true
          }
        },
        {
          "insert": " e "
        },
        {
          "insert": "CORAGEM",
          "attributes": {
            "bold": true,
            "underline": true
          }
        },
        {
          "insert": ".\n"
        }
      ]
    }
```

</details>

That repeats the following block:

```json
{
          "insert": ", "
        },
```
