### PR TITLE
Adds `localMemo` validation

### DIFF
--- a/firebase/src/core/domain/models/collection.ts
+++ b/firebase/src/core/domain/models/collection.ts
@@ -1,4 +1,4 @@
-import { Memo, memoValidationSchema } from "#domain/models/memo";
+import { localMemoValidationSchema, Memo } from "#domain/models/memo";
 import { defaultMaxStringLength, validate } from "#utils/validate";
 import * as Joi from "joi";
 
@@ -75,7 +75,7 @@ export const publicCollectionSchema = Joi.object({
 });
 
 export const localCollectionSchema = publicCollectionSchema.append({
-  memos: Joi.array().items(memoValidationSchema).unique().min(1).required(),
+  memos: Joi.array().items(localMemoValidationSchema).unique().min(1).required(),
 });
 
 export const storedCollectionSchema = publicCollectionSchema.append({

--- a/firebase/src/core/domain/models/memo.ts
+++ b/firebase/src/core/domain/models/memo.ts
@@ -1,30 +1,49 @@
 import { defaultMaxStringLength, validate } from "#utils/validate";
 import * as Joi from "joi";
 
-interface MemoContent {
+interface Attributes {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+}
+
+interface MemoAttributes extends Attributes {
+  codeBlock?: boolean;
+}
+
+// Local stored memos use kebab-case in its attributes instead camel-case.
+interface LocalMemoAttributes extends Attributes {
+  "code-block"?: boolean;
+}
+
+interface MemoContent<T extends Attributes> {
   insert: string;
-  attributes?: {
-    bold?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-    codeBlock?: boolean;
-  };
+  attributes?: T;
 }
 
 export interface Memo {
   readonly id: string;
-  readonly question: MemoContent[];
-  readonly answer: MemoContent[];
+  readonly question: MemoContent<MemoAttributes>[];
+  readonly answer: MemoContent<MemoAttributes>[];
 }
 
+export interface LocalMemo {
+  readonly id: string;
+  readonly question: MemoContent<LocalMemoAttributes>[];
+  readonly answer: MemoContent<LocalMemoAttributes>[];
+}
+
+const attributeValidation = Joi.object({
+  bold: Joi.boolean(),
+  italic: Joi.boolean(),
+  underline: Joi.boolean(),
+}).min(1);
+
 export const memoQuillValidationSchema = Joi.object({
-  insert: Joi.string().max(defaultMaxStringLength).required(),
-  attributes: Joi.object({
-    bold: Joi.boolean(),
-    italic: Joi.boolean(),
-    underline: Joi.boolean(),
+  insert: Joi.string().required(),
+  attributes: attributeValidation.append({
     codeBlock: Joi.boolean(),
-  }).min(1),
+  }),
 });
 
 export const memoValidationSchema = Joi.object({
@@ -35,4 +54,21 @@ export const memoValidationSchema = Joi.object({
 
 export function validateMemo(memo: Memo): void {
   validate(memoValidationSchema, memo);
+}
+
+export const localMemoQuillValidationSchema = Joi.object({
+  insert: Joi.string().required(),
+  attributes: attributeValidation.append({
+    "code-block": Joi.boolean(),
+  }),
+});
+
+export const localMemoValidationSchema = Joi.object({
+  id: Joi.string().max(defaultMaxStringLength).required(),
+  question: Joi.array().items(localMemoQuillValidationSchema).min(1).required(),
+  answer: Joi.array().items(localMemoQuillValidationSchema).min(1).required(),
+});
+
+export function validateLocalMemo(localMemo: LocalMemo): void {
+  validate(localMemoValidationSchema, localMemo);
 }

--- a/firebase/src/core/domain/use-cases/collections/sync-collections.ts
+++ b/firebase/src/core/domain/use-cases/collections/sync-collections.ts
@@ -9,7 +9,7 @@ import {
   validateLocalCollection,
   validateStoredCollection,
 } from "#domain/models/collection";
-import { Memo, validateMemo } from "#domain/models/memo";
+import { Memo, validateLocalMemo } from "#domain/models/memo";
 import { GitRepository } from "#data/repositories/git-repository";
 
 type CollectionMemosDiff = [Memo[], string[]];
@@ -126,7 +126,7 @@ export class SyncCollectionsUseCase {
 
     const storedMemos = await this.#memosRepo.getAllMemos(collectionId);
     for (const localMemo of localMemos) {
-      validateMemo(localMemo);
+      validateLocalMemo(localMemo);
 
       const storedMemo = storedMemos.find((storedMemo) => storedMemo.id === localMemo.id);
       if (!objectsEqual(storedMemo, localMemo)) {


### PR DESCRIPTION
Needed to split `Memo` entity to support `kebab-case` in local stored memos. Similar how it's being made with the collections.